### PR TITLE
Resolve error when running in Node.js

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -124,7 +124,7 @@ export class StdDateAdapter implements DateAdapter {
   }
 
   constructor(locale?:string) {
-    this.updateLocale(locale || navigator.language || "en-US");
+    this.updateLocale(locale || globalThis?.window?.navigator.language || "en-US");
     for (const label of this.formatLabels) {
       (this.FORMATS)[label] = label;
     }


### PR DESCRIPTION
Using `globalThis.window` before `navigator` (and optional chaining) to prevent errors in Node.js. If running in Node.js, the logic will use the provided locale parameter, and if that is falsy, it will fallback on the default "en-US", skipping over the attempt to access the browser-only Navigation API.